### PR TITLE
feat: non-xtal-mutant

### DIFF
--- a/src/RosettaPy/__init__.py
+++ b/src/RosettaPy/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "RosettaCartesianddGAnalyser",
 ]
 
-__version__ = "0.2.8"
+__version__ = "0.2.9"

--- a/src/RosettaPy/app/cart_ddg.py
+++ b/src/RosettaPy/app/cart_ddg.py
@@ -184,4 +184,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main(True)
+    main(False)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property in the `Mutant` class to generate instances with 'X' residues removed, adjusting mutation positions accordingly.
  
- **Bug Fixes**
	- Adjusted the invocation of the main function to change the behavior of ddG calculations when executed directly.

- **Tests**
	- Added a new test function to validate the behavior of the `non_xtal` property, covering various scenarios involving 'X' residues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->