### PR TITLE
fix(python-version): added 3.13/3.14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,11 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - "3.8"
+          # - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
+          - "3.14"
 
     uses: YaoYinYing/action-python/.github/workflows/validation.yml@v7.3.1-post-6
     with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          # - "3.8"
+          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14"
+          - "3.14.0-rc.2"
 
     uses: YaoYinYing/action-python/.github/workflows/validation.yml@v7.3.1-post-6
     with:

--- a/.github/workflows/RosettaCI.yml
+++ b/.github/workflows/RosettaCI.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup RosettaPy on ${{ matrix.os }}
         run: |
           apt-get update -y
-          apt-get install build-essential gnupg2 git -y
+          apt-get install build-essential gnupg2 git curl -y
           bash scripts/upgrade_git.sh
           pip install '.[test]' -U
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,10 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dynamic = ["version"]
 
 dependencies = [

--- a/src/RosettaPy/__init__.py
+++ b/src/RosettaPy/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "RosettaCartesianddGAnalyser",
 ]
 
-__version__ = "0.2.13"
+__version__ = "0.2.14"


### PR DESCRIPTION
as rdkit now support Py3.13 and 3.14
see: https://pypi.org/project/rdkit/2025.3.6/#files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Declared official support for Python 3.13 and 3.14 in project metadata; package version bumped to 0.2.14. Minimum Python requirement remains >=3.8.

* **Tests**
  * Updated CI matrix: added 3.13 and 3.14 (rc). CI still covers 3.8–3.11.
  * CI environment now installs curl during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->